### PR TITLE
feat: read properties from d2rc file and merge with defaults

### DIFF
--- a/lib/configDefaults.js
+++ b/lib/configDefaults.js
@@ -1,7 +1,11 @@
 const os = require('os')
 const path = require('path')
 
-module.exports = {
+const reporter = require('./reporter')
+
+const configFile = path.join(os.homedir(), '.d2rc')
+
+const defaultConfig = {
     verbose: false,
     cache: path.join(os.homedir(), '.cache/d2'),
     cluster: {
@@ -10,4 +14,17 @@ module.exports = {
         demoDatabaseURL:
             'https://github.com/dhis2/dhis2-demo-db/blob/master/sierra-leone/{version}/dhis2-db-sierra-leone.sql.gz?raw=true',
     },
+}
+
+let userConfig
+try {
+    userConfig = require(configFile)
+    reporter.debug(`User configuration loaded from: ${configFile}`)
+} catch (e) {
+    reporter.debug(`Failed to load user config from: ${configFile}`)
+}
+
+module.exports = {
+    ...defaultConfig,
+    ...userConfig,
 }

--- a/lib/configDefaults.js
+++ b/lib/configDefaults.js
@@ -15,7 +15,10 @@ const userConfig = () => {
         const configFile = files.filter(f => configPattern.test(f))[0]
 
         const userConfig = require(path.join(configDir, configFile))
-        reporter.debug(`User configuration loaded from: ${configFile}`, userConfig)
+        reporter.debug(
+            `User configuration loaded from: ${configFile}`,
+            userConfig
+        )
 
         return userConfig
     } catch (e) {

--- a/lib/configDefaults.js
+++ b/lib/configDefaults.js
@@ -3,8 +3,6 @@ const path = require('path')
 
 const reporter = require('./reporter')
 
-const configDir = path.join(os.homedir(), '.config', 'd2')
-
 const tryLoadConfig = file => {
     try {
         const userConfig = require(file)
@@ -17,6 +15,8 @@ const tryLoadConfig = file => {
 }
 
 const userConfig = () => {
+    const configDir = path.join(os.homedir(), '.config', 'd2')
+
     const configPriority = [
         path.join(configDir, 'config.js'),
         path.join(configDir, 'd2.config.js'),

--- a/lib/configDefaults.js
+++ b/lib/configDefaults.js
@@ -1,30 +1,35 @@
 const os = require('os')
 const path = require('path')
-const fs = require('fs')
 
 const reporter = require('./reporter')
 
-const userConfig = () => {
-    const configDir = path.join(os.homedir(), '.config', 'd2')
-    const configPattern = /^(d2\.)*(config)\.(js$|json$)/
+const configDir = path.join(os.homedir(), '.config', 'd2')
 
+const tryLoadConfig = file => {
     try {
-        const files = fs.readdirSync(configDir)
-
-        // grab one of the config files if there are more than one
-        const configFile = files.filter(f => configPattern.test(f))[0]
-
-        const userConfig = require(path.join(configDir, configFile))
-        reporter.debug(
-            `User configuration loaded from: ${configFile}`,
-            userConfig
-        )
-
+        const userConfig = require(file)
+        reporter.debug(`User configuration loaded from: ${file}`)
         return userConfig
     } catch (e) {
-        reporter.debug(`Failed to load user config from: ${configDir}`, e)
-        return {}
+        reporter.debug(`Failed to load user config from: ${file}`)
+        return null
     }
+}
+
+const userConfig = () => {
+    const configPriority = [
+        path.join(configDir, 'config.js'),
+        path.join(configDir, 'd2.config.js'),
+        path.join(configDir, 'config.json'),
+        path.join(configDir, 'd2.config.json'),
+    ]
+
+    for (const f of configPriority) {
+        const config = tryLoadConfig(f)
+        if (config) return config
+    }
+
+    return {}
 }
 
 const defaultConfig = {

--- a/lib/configDefaults.js
+++ b/lib/configDefaults.js
@@ -1,9 +1,28 @@
 const os = require('os')
 const path = require('path')
+const fs = require('fs')
 
 const reporter = require('./reporter')
 
-const configFile = path.join(os.homedir(), '.d2rc')
+const userConfig = () => {
+    const configDir = path.join(os.homedir(), '.config', 'd2')
+    const configPattern = /^(d2\.)*(config)\.(js$|json$)/
+
+    try {
+        const files = fs.readdirSync(configDir)
+
+        // grab one of the config files if there are more than one
+        const configFile = files.filter(f => configPattern.test(f))[0]
+
+        const userConfig = require(path.join(configDir, configFile))
+        reporter.debug(`User configuration loaded from: ${configFile}`, userConfig)
+
+        return userConfig
+    } catch (e) {
+        reporter.debug(`Failed to load user config from: ${configDir}`, e)
+        return {}
+    }
+}
 
 const defaultConfig = {
     verbose: false,
@@ -16,15 +35,7 @@ const defaultConfig = {
     },
 }
 
-let userConfig
-try {
-    userConfig = require(configFile)
-    reporter.debug(`User configuration loaded from: ${configFile}`)
-} catch (e) {
-    reporter.debug(`Failed to load user config from: ${configFile}`)
-}
-
 module.exports = {
     ...defaultConfig,
-    ...userConfig,
+    ...userConfig(),
 }


### PR DESCRIPTION
I was looking around for the default configuration file that `d2` looks for, I thought it was `~/.d2rc` or something like it but the only code relating to loading config I found was here: https://github.com/dhis2/cli-helpers-engine/blob/master/lib/makeEntryPoint.js#L20-L28

I figured that it made sense to try to load the `.d2rc` file in `configDefaults.js` and merge the user configuration early in the chain: `defaults -> ~/.d2rc -> --config <file> -> env variables -> package.json key`.

Maybe this exists elsewhere and I just didn't find it?