### PR TITLE
fix: move the command configuration to the module itself

### DIFF
--- a/lib/configDefaults.js
+++ b/lib/configDefaults.js
@@ -35,12 +35,6 @@ const userConfig = () => {
 const defaultConfig = {
     verbose: false,
     cache: path.join(os.homedir(), '.cache/d2'),
-    cluster: {
-        dockerComposeRepository:
-            'https://github.com/amcgee/dhis2-backend/archive/master.tar.gz',
-        demoDatabaseURL:
-            'https://github.com/dhis2/dhis2-demo-db/blob/master/sierra-leone/{version}/dhis2-db-sierra-leone.sql.gz?raw=true',
-    },
 }
 
 module.exports = {


### PR DESCRIPTION
Depends on: https://github.com/dhis2/cli/pull/46

Should be merged after that.

The idea is that global configuration options (e.g. `verbose`, `cache`) go here, but the command modules ship with their own default configuration which can be overridden by the configuration file. See https://github.com/dhis2/cli/pull/46 for an example of how to do that.

At some point we want something more sophisticated than: `cliArg || configFile || defaultValue`. The semantics are correct; it is just error prone to deal with everywhere.