### PR TITLE
fix: verify statuscode is between 200-399

### DIFF
--- a/lib/cache/fetchAndExtract.js
+++ b/lib/cache/fetchAndExtract.js
@@ -30,6 +30,14 @@ module.exports = async ({ url, name, tmpLoc, outLoc, raw, requestOpts }) => {
             reporter.debug(`[CACHE]   tmpLoc ${chalk.bold(tmpLoc)}`)
             await fs.ensureDir(tmpLoc)
             downloadStream
+                .on('response', (response) => {
+                    //Simple check here, assume all 2xx and 3xx codes is ok
+                    if ( response.statusCode >= 200 && response.statusCode <= 399 ) {
+                        downloadStream.resume()
+                    } else {
+                        reject(`Failed to download ${chalk.bold(url)}, got statusCode ${response.statusCode}`)
+                    }
+                })
                 .pipe(
                     tar.extract({
                         strip: 1,
@@ -59,6 +67,14 @@ module.exports = async ({ url, name, tmpLoc, outLoc, raw, requestOpts }) => {
             reporter.debug(`[CACHE]   to ${chalk.bold(outLoc)}`)
             const writeStream = fs.createWriteStream(outLoc)
             downloadStream
+                .on('response', (response) => {
+                    //Simple check here, assume all 2xx and 3xx codes is ok
+                    if ( response.statusCode >= 200 && response.statusCode <= 399 ) {
+                        downloadStream.resume()
+                    } else {
+                        reject(`Failed to download ${chalk.bold(url)}, got statusCode ${response.statusCode}`)
+                    }
+                })
                 .pipe(writeStream)
                 // WriteStream uses `close`, not `end`
                 .on('close', function() {


### PR DESCRIPTION
This resolves issues with for example d2 cluster to not download 404 pages from github when fetching databases that doesn't exist