### PR TITLE
fix: use shell: true option in exec to support windows

### DIFF
--- a/lib/exec.js
+++ b/lib/exec.js
@@ -21,6 +21,7 @@ module.exports = function({
 
     const p = new Promise((resolve, reject) => {
         const child = spawn(cmd, args, {
+            shell: true,
             ...opts,
             env: childEnv,
         })

--- a/lib/exec.js
+++ b/lib/exec.js
@@ -22,8 +22,8 @@ module.exports = function({
     const p = new Promise((resolve, reject) => {
         const child = spawn(cmd, args, {
             shell: true,
-            ...opts,
             env: childEnv,
+            ...opts,
         })
         let output = captureOut || captureErr ? '' : undefined
 


### PR DESCRIPTION
This allows execution of "commands" in addition to "programs" on windows.