### PR TITLE
feat: add a prompt utility which wraps inquirer, add docs to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,9 @@ const handler = async ({ force, getCache }) => {
 
     // List all currently-downloaded databases
 
-    const dirStat = await cache.exists('databases') ? await cache.stat('databases') : null
+    const dirStat = (await cache.exists('databases'))
+        ? await cache.stat('databases')
+        : null
     if (dirStat && dirStat.children) {
         Object.entries(dirStat.children)
             .forEach(([name, stat]) => {

--- a/README.md
+++ b/README.md
@@ -9,6 +9,92 @@
 > This is the engine used by plugin modules in the [@dhis2/cli](https://github.com/dhis2/cli)
 > commandline interface ecosystem.
 
+## A few common utilities:
+
+These helpers assume a node.js CLI context.  There are other under-the-hood helpers as well, but they are currently undocumented.
+
+```js
+const { reporter, chalk, prompt, exec } = require('@dhis2/cli-helpers-engine')
+
+// These are wrappers around stdout and stderr which respect the --verbose and --quiet flags.  Some reporting options also prefix the line with a tag - see lib/reporter.js for all the options
+reporter.print('This is a test') // Only printed if --quiet is not passed
+reporter.print(chalk.dim('This is a less important test'))
+reporter.print(chalk.green(`Chalk can be used to ${chalk.bold('style text')} which will be printed to the console.`))
+reporter.info('This is something important') // prints to stdout in cyan: This is something important
+reporter.error('An error occurred') // prints to stderr in red: [ERROR] An error occured
+reporter.warn('Something non-critical went wrong') // prints to stderr in yellow: [WARNING] Something non-critical went wrong
+reporter.debug('This will only be printed when --verbose is passed') // prints to stdout if --verbose in dim gray: [DEBUG] This will only be printed when --verbose is passed
+
+// Use prompt to ask the user for input - it is a thin wrapper around `inquirer.prompt`, see https://github.com/SBoudrias/Inquirer.js
+const answers = await prompt([
+    {
+      type: 'list',
+      name: 'theme',
+      message: 'What do you want to do?',
+      choices: [
+        'Order a pizza',
+        'Make a reservation',
+        new inquirer.Separator(),
+        'Ask for opening hours',
+        {
+          name: 'Contact support',
+          disabled: 'Unavailable at this time',
+        },
+        'Talk to the receptionist',
+      ],
+    },
+    {
+      type: 'list',
+      name: 'size',
+      message: 'What size do you need?',
+      choices: ['Jumbo', 'Large', 'Standard', 'Medium', 'Small', 'Micro'],
+      filter: function (val) {
+        return val.toLowerCase();
+      },
+      when: function (answers) {
+        return answers.theme === 'Order a pizza';
+      },
+    }
+])
+if (answers.theme === 'Order a pizza') {
+    reporter.info(`Ordering a ${answers.size} pizza`)
+} else {
+    reporter.info(`Ok, let's ${answers.theme}`)
+}
+
+// Exec a function in the local shell environment, pass some arguments, set the current working directory, and capture the output as a string
+
+const textContents = await exec({
+    cmd: 'cat',
+    args: ['./test.txt'],
+    cwd: './myDirectory',
+    captureOut: true
+})
+```
+
+There's a lot more you can do with these utilities - check the source code in the `./libs` folder or the many CLI module examples at [dhis2/cli](https://github.com/dhis2/cli) for inspiration.
+
+## How to use the d2 Cache
+
+Any CLI command instantiated with `@dhis2/cli-helpers-engine` will have an injected `getCache` argument.  This is a powerful, simple cache engine for downloading, caching, and accessing files in the global `d2` cache.
+
+The most handy method of the `d2` Cache is `get`, which allows the developer to fetch a remote URL, optionally extract it if the download is a zip file, and store it in the cache.  If a copy already exists in the cache, the download is skipped (unless `force: true` is specified):
+
+```js
+const url = 'https://spreadsheets.google.com/feeds/list/1Fd-vBoJPjp5wdCyJc7d_LOJPOg5uqdzVa3Eq5-VFR-g/2/public/values?alt=json'
+
+// This will download a json file listing all countries which implement DHIS2 and store it in 
+cache.get(url, 'dhis2-in-action-countries.json', { force: true })
+
+// And now an example for a zip file
+const dbUrl = 'https://databases.dhis2.org/sierra-leone/2.35.0/dhis2-db-sierra-leone.sql.gz'
+
+// This will download the demo database for 2.35.0 and store it in the cache.  The 'raw' option means the .gz file will NOT be unpacked, but rather stored directly on disk.  If a version of this file already exists in the cache, it will not be fetched again.
+cache.get(dbUrl, 'databases/2.35.0.sql.gz', { raw: true })
+```
+
+For examples of the cache in action, check out its use in [d2 cluster](https://github.com/dhis2/cli/blob/master/packages/cluster/src/common.js#L11-L52) and [d2 debug cache](https://github.com/dhis2/cli/blob/master/packages/main/src/commands/debug/cache.js)
+
 ## Report an issue
 
 The issue tracker can be found in [DHIS2 JIRA](https://jira.dhis2.org)

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 ## A few common utilities:
 
-These helpers assume a node.js CLI context.  There are other under-the-hood helpers as well, but they are currently undocumented.
+These helpers assume a node.js CLI context. There are other under-the-hood helpers as well, but they are currently undocumented.
 
 ```js
 const { reporter, chalk, prompt, exec } = require('@dhis2/cli-helpers-engine')
@@ -19,7 +19,13 @@ const { reporter, chalk, prompt, exec } = require('@dhis2/cli-helpers-engine')
 // These are wrappers around stdout and stderr which respect the --verbose and --quiet flags.  Some reporting options also prefix the line with a tag - see lib/reporter.js for all the options
 reporter.print('This is a test') // Only printed if --quiet is not passed
 reporter.print(chalk.dim('This is a less important test'))
-reporter.print(chalk.green(`Chalk can be used to ${chalk.bold('style text')} which will be printed to the console.`))
+reporter.print(
+    chalk.green(
+        `Chalk can be used to ${chalk.bold(
+            'style text'
+        )} which will be printed to the console.`
+    )
+)
 reporter.info('This is something important') // prints to stdout in cyan: This is something important
 reporter.error('An error occurred') // prints to stderr in red: [ERROR] An error occured
 reporter.warn('Something non-critical went wrong') // prints to stderr in yellow: [WARNING] Something non-critical went wrong
@@ -28,33 +34,33 @@ reporter.debug('This will only be printed when --verbose is passed') // prints t
 // Use prompt to ask the user for input - it is a thin wrapper around `inquirer.prompt`, see https://github.com/SBoudrias/Inquirer.js
 const answers = await prompt([
     {
-      type: 'list',
-      name: 'theme',
-      message: 'What do you want to do?',
-      choices: [
-        'Order a pizza',
-        'Make a reservation',
-        new inquirer.Separator(),
-        'Ask for opening hours',
-        {
-          name: 'Contact support',
-          disabled: 'Unavailable at this time',
-        },
-        'Talk to the receptionist',
-      ],
+        type: 'list',
+        name: 'theme',
+        message: 'What do you want to do?',
+        choices: [
+            'Order a pizza',
+            'Make a reservation',
+            new inquirer.Separator(),
+            'Ask for opening hours',
+            {
+                name: 'Contact support',
+                disabled: 'Unavailable at this time',
+            },
+            'Talk to the receptionist',
+        ],
     },
     {
-      type: 'list',
-      name: 'size',
-      message: 'What size do you need?',
-      choices: ['Jumbo', 'Large', 'Standard', 'Medium', 'Small', 'Micro'],
-      filter: function (val) {
-        return val.toLowerCase();
-      },
-      when: function (answers) {
-        return answers.theme === 'Order a pizza';
-      },
-    }
+        type: 'list',
+        name: 'size',
+        message: 'What size do you need?',
+        choices: ['Jumbo', 'Large', 'Standard', 'Medium', 'Small', 'Micro'],
+        filter: function (val) {
+            return val.toLowerCase()
+        },
+        when: function (answers) {
+            return answers.theme === 'Order a pizza'
+        },
+    },
 ])
 if (answers.theme === 'Order a pizza') {
     reporter.info(`Ordering a ${answers.size} pizza`)
@@ -68,7 +74,7 @@ const textContents = await exec({
     cmd: 'cat',
     args: ['./test.txt'],
     cwd: './myDirectory',
-    captureOut: true
+    captureOut: true,
 })
 ```
 
@@ -76,18 +82,20 @@ There's a lot more you can do with these utilities - check the source code in th
 
 ## How to use the d2 Cache
 
-Any CLI command instantiated with `@dhis2/cli-helpers-engine` will have an injected `getCache` argument.  This is a powerful, simple cache engine for downloading, caching, and accessing files in the global `d2` cache.
+Any CLI command instantiated with `@dhis2/cli-helpers-engine` will have an injected `getCache` argument. This is a powerful, simple cache engine for downloading, caching, and accessing files in the global `d2` cache.
 
-The most handy method of the `d2` Cache is `get`, which allows the developer to fetch a remote URL, optionally extract it if the download is a zip file, and store it in the cache.  If a copy already exists in the cache, the download is skipped (unless `force: true` is specified):
+The most handy method of the `d2` Cache is `get`, which allows the developer to fetch a remote URL, optionally extract it if the download is a zip file, and store it in the cache. If a copy already exists in the cache, the download is skipped (unless `force: true` is specified):
 
 ```js
-const url = 'https://spreadsheets.google.com/feeds/list/1Fd-vBoJPjp5wdCyJc7d_LOJPOg5uqdzVa3Eq5-VFR-g/2/public/values?alt=json'
+const url =
+    'https://spreadsheets.google.com/feeds/list/1Fd-vBoJPjp5wdCyJc7d_LOJPOg5uqdzVa3Eq5-VFR-g/2/public/values?alt=json'
 
-// This will download a json file listing all countries which implement DHIS2 and store it in 
+// This will download a json file listing all countries which implement DHIS2 and store it in
 cache.get(url, 'dhis2-in-action-countries.json', { force: true })
 
 // And now an example for a zip file
-const dbUrl = 'https://databases.dhis2.org/sierra-leone/2.35.0/dhis2-db-sierra-leone.sql.gz'
+const dbUrl =
+    'https://databases.dhis2.org/sierra-leone/2.35.0/dhis2-db-sierra-leone.sql.gz'
 
 // This will download the demo database for 2.35.0 and store it in the cache.  The 'raw' option means the .gz file will NOT be unpacked, but rather stored directly on disk.  If a version of this file already exists in the cache, it will not be fetched again.
 cache.get(dbUrl, 'databases/2.35.0.sql.gz', { raw: true })

--- a/index.js
+++ b/index.js
@@ -1,10 +1,17 @@
-module.exports.Cache = require('./lib/cache')
-module.exports.exec = require('./lib/exec')
+// Under-the-hood utilities for building CLI modules
 module.exports.groupGlobalOptions = require('./lib/groupGlobalOptions')
 module.exports.makeEntryPoint = require('./lib/makeEntryPoint')
 module.exports.namespace = require('./lib/namespace')
 module.exports.notifyOfUpdates = require('./lib/notifyOfUpdates')
-module.exports.reporter = require('./lib/reporter')
 module.exports.tryCatchAsync = require('./lib/tryCatchAsync')
 module.exports.configDefaults = require('./lib/configDefaults')
+
+// The Cache constructor
+module.exports.Cache = require('./lib/cache')
+
+// Utility functions for interacting with the cli user
+module.exports.reporter = require('./lib/reporter')
+module.exports.exec = require('./lib/exec')
 module.exports.chalk = require('chalk')
+module.exports.prompt = require('./lib/prompt')
+module.exports.inquirer = require('inquirer')

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ module.exports.configDefaults = require('./lib/configDefaults')
 // The Cache constructor
 module.exports.Cache = require('./lib/cache')
 
-// Utility functions for interacting with the cli user
+// Utility functions for interacting with the cli user or spawning sidecar processes
 module.exports.reporter = require('./lib/reporter')
 module.exports.exec = require('./lib/exec')
 module.exports.chalk = require('chalk')

--- a/lib/prompt.js
+++ b/lib/prompt.js
@@ -1,4 +1,4 @@
-var inquirer = require('inquirer')
+const inquirer = require('inquirer')
 const reporter = require('./reporter')
 
 const prompt = questions => {

--- a/lib/prompt.js
+++ b/lib/prompt.js
@@ -1,19 +1,17 @@
-var inquirer = require('inquirer');
-const reporter = require('./reporter');
+var inquirer = require('inquirer')
+const reporter = require('./reporter')
 
-const prompt = (questions) => {
-    return inquirer
-        .prompt(questions)
-        .catch(error => {
-            if(error.isTtyError) {
-                reporter.error('Failed to prompt for user input!')
-                process.exit(1)
-            } else {
-                reporter.error('An unknown error occured while prompting for input')
-                reporter.debugErr(error)
-                process.exit(1)
-            }
-        });
+const prompt = questions => {
+    return inquirer.prompt(questions).catch(error => {
+        if (error.isTtyError) {
+            reporter.error('Failed to prompt for user input!')
+            process.exit(1)
+        } else {
+            reporter.error('An unknown error occured while prompting for input')
+            reporter.debugErr(error)
+            process.exit(1)
+        }
+    })
 }
 
 module.exports = prompt

--- a/lib/prompt.js
+++ b/lib/prompt.js
@@ -11,6 +11,7 @@ const prompt = (questions) => {
             } else {
                 reporter.error('An unknown error occured while prompting for input')
                 reporter.debugErr(error)
+                process.exit(1)
             }
         });
 }

--- a/lib/prompt.js
+++ b/lib/prompt.js
@@ -1,0 +1,18 @@
+var inquirer = require('inquirer');
+const reporter = require('./reporter');
+
+const prompt = (questions) => {
+    return inquirer
+        .prompt(questions)
+        .catch(error => {
+            if(error.isTtyError) {
+                reporter.error('Failed to prompt for user input!')
+                process.exit(1)
+            } else {
+                reporter.error('An unknown error occured while prompting for input')
+                reporter.debugErr(error)
+            }
+        });
+}
+
+module.exports = prompt

--- a/package.json
+++ b/package.json
@@ -29,5 +29,9 @@
             "commit-msg": "d2-style commit check",
             "pre-commit": "d2-style js apply"
         }
+    },
+    "scripts": {
+        "lint": "d2-style js check && d2-style text check",
+        "format": "d2-style js apply && d2-style text apply"
     }
 }


### PR DESCRIPTION
This is a really small feature adding a `prompt` utility to `@dhis2/cli-helpers-engine` (it just proxies through to [inquirer](https://github.com/SBoudrias/Inquirer.js#examples) and catches errors)

I also took the opportunity to add some very light-weight docs/examples to the README, though this library is still mostly undocumented