### PR TITLE
feat: add additional process exec functions

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,8 +10,11 @@ module.exports.configDefaults = require('./lib/configDefaults')
 module.exports.Cache = require('./lib/cache')
 
 // Utility functions for interacting with the cli user or spawning sidecar processes
+module.exports.exec = require('./lib/exec.js')
 module.exports.reporter = require('./lib/reporter')
-module.exports.exec = require('./lib/exec')
-module.exports.chalk = require('chalk')
+module.exports.process = require('./lib/process.js')
 module.exports.prompt = require('./lib/prompt')
+
+// Access to wrapped libraries
+module.exports.chalk = require('chalk')
 module.exports.inquirer = require('inquirer')

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ module.exports.Cache = require('./lib/cache')
 // Utility functions for interacting with the cli user or spawning sidecar processes
 module.exports.exec = require('./lib/exec.js')
 module.exports.reporter = require('./lib/reporter')
-module.exports.process = require('./lib/process.js')
+module.exports.exit = require('./lib/exit.js')
 module.exports.prompt = require('./lib/prompt')
 
 // Access to wrapped libraries

--- a/lib/exec.js
+++ b/lib/exec.js
@@ -3,6 +3,7 @@ const xspawn = require('cross-spawn')
 const chalk = require('chalk')
 const findup = require('find-up')
 const reporter = require('./reporter.js')
+const { exit } = require('./process.js')
 
 function exec({ cmd, args, env, pipe, captureOut, captureErr, ...opts }) {
     reporter.debug(`> ${cmd} ${args.join(' ')}`)
@@ -108,14 +109,6 @@ function callback() {
     }
 }
 
-function exit(code, msg) {
-    if (msg && code > 0) {
-        reporter.print('')
-        reporter.error(msg)
-    }
-    process.exit(code)
-}
-
 function handleRun(result, callback) {
     if (result.error) {
         throw result.error
@@ -134,7 +127,6 @@ function handleRun(result, callback) {
 module.exports = exec
 
 // named exports
-module.exports.exit = exit
 module.exports.spawn = spawn
 module.exports.run = run
 module.exports.bin = bin

--- a/lib/exec.js
+++ b/lib/exec.js
@@ -134,7 +134,7 @@ function handleRun(result, callback) {
     }
 
     if (result.status !== 0) {
-        process.exit(result.status === null ? 0 : result.status)
+        exit(result.status === null ? 0 : result.status)
     }
 }
 

--- a/lib/exec.js
+++ b/lib/exec.js
@@ -3,7 +3,7 @@ const xspawn = require('cross-spawn')
 const chalk = require('chalk')
 const findup = require('find-up')
 const reporter = require('./reporter.js')
-const { exit } = require('./process.js')
+const exit = require('./exit.js')
 
 function exec({ cmd, args, env, pipe, captureOut, captureErr, ...opts }) {
     reporter.debug(`> ${cmd} ${args.join(' ')}`)

--- a/lib/exec.js
+++ b/lib/exec.js
@@ -1,8 +1,10 @@
-const { spawn } = require('child_process')
+const path = require('path')
+const xspawn = require('cross-spawn')
 const chalk = require('chalk')
-const reporter = require('./reporter')
+const findup = require('find-up')
+const reporter = require('./reporter.js')
 
-module.exports = function ({
+function exec ({
     cmd,
     args,
     env,
@@ -20,7 +22,7 @@ module.exports = function ({
     reporter.debug(`env: ${JSON.stringify(env)}`)
 
     const p = new Promise((resolve, reject) => {
-        const child = spawn(cmd, args, {
+        const child = xspawn(cmd, args, {
             shell: true,
             env: childEnv,
             ...opts,
@@ -65,4 +67,83 @@ module.exports = function ({
     })
 
     return p
+}
+
+function spawn (cmd, args, opts) {
+    reporter.debug(cmd, args, opts)
+    return xspawn.sync(cmd, args, {
+        stdio: 'inherit',
+        ...opts,
+    })
+}
+
+function run (cmd, { args, opts }, callback) {
+    return handleRun(
+        spawn(cmd, args, {
+            stdio: 'inherit',
+            ...opts,
+        }),
+        callback
+    )
+}
+
+function bin (cmd, { args, cwd = process.cwd(), opts }, callback) {
+    const nodemodules = findup.sync('node_modules', {
+        cwd,
+        type: 'directory',
+        allowSymlinks: true,
+    })
+
+    const binCmd = path.join(nodemodules, '.bin', cmd)
+
+    return handleRun(
+        spawn(binCmd, args, {
+            stdio: 'inherit',
+            ...opts,
+        }),
+        callback
+    )
+}
+
+function callback () {
+    let status = 0
+    return result => {
+        if (!result) return status
+
+        if (result.status > status) {
+            status = result.status
+        }
+    }
+}
+
+function exit (code, msg) {
+    if (msg && code > 0) {
+        reporter.print('')
+        reporter.error(msg)
+    }
+    process.exit(code)
+}
+
+function handleRun(result, callback) {
+    if (result.error) {
+        throw result.error
+    }
+
+    if (callback) {
+        return callback(result)
+    }
+
+    if (result.status !== 0) {
+        process.exit(result.status === null ? 0 : result.status)
+    }
+}
+
+module.exports = {
+    exec,
+    exit,
+    spawn,
+    run,
+    bin,
+    callback,
+    default: exec,
 }

--- a/lib/exec.js
+++ b/lib/exec.js
@@ -4,15 +4,7 @@ const chalk = require('chalk')
 const findup = require('find-up')
 const reporter = require('./reporter.js')
 
-function exec ({
-    cmd,
-    args,
-    env,
-    pipe,
-    captureOut,
-    captureErr,
-    ...opts
-}) {
+function exec({ cmd, args, env, pipe, captureOut, captureErr, ...opts }) {
     reporter.debug(`> ${cmd} ${args.join(' ')}`)
 
     const childEnv = {
@@ -69,7 +61,7 @@ function exec ({
     return p
 }
 
-function spawn (cmd, args, opts) {
+function spawn(cmd, args, opts) {
     reporter.debug(cmd, args, opts)
     return xspawn.sync(cmd, args, {
         stdio: 'inherit',
@@ -77,7 +69,7 @@ function spawn (cmd, args, opts) {
     })
 }
 
-function run (cmd, { args, opts }, callback) {
+function run(cmd, { args, opts }, callback) {
     return handleRun(
         spawn(cmd, args, {
             stdio: 'inherit',
@@ -87,7 +79,7 @@ function run (cmd, { args, opts }, callback) {
     )
 }
 
-function bin (cmd, { args, cwd = process.cwd(), opts }, callback) {
+function bin(cmd, { args, cwd = process.cwd(), opts }, callback) {
     const nodemodules = findup.sync('node_modules', {
         cwd,
         type: 'directory',
@@ -105,7 +97,7 @@ function bin (cmd, { args, cwd = process.cwd(), opts }, callback) {
     )
 }
 
-function callback () {
+function callback() {
     let status = 0
     return result => {
         if (!result) return status
@@ -116,7 +108,7 @@ function callback () {
     }
 }
 
-function exit (code, msg) {
+function exit(code, msg) {
     if (msg && code > 0) {
         reporter.print('')
         reporter.error(msg)

--- a/lib/exec.js
+++ b/lib/exec.js
@@ -138,12 +138,12 @@ function handleRun(result, callback) {
     }
 }
 
-module.exports = {
-    exec,
-    exit,
-    spawn,
-    run,
-    bin,
-    callback,
-    default: exec,
-}
+// default export
+module.exports = exec
+
+// named exports
+module.exports.exit = exit
+module.exports.spawn = spawn
+module.exports.run = run
+module.exports.bin = bin
+module.exports.callback = callback

--- a/lib/exit.js
+++ b/lib/exit.js
@@ -1,6 +1,7 @@
+const process = require('process')
 const reporter = require('./reporter.js')
 
-exports.exit = (code, msg) => {
+module.exports = (code, msg) => {
     if (msg && code > 0) {
         reporter.print('')
         reporter.error(msg)

--- a/lib/process.js
+++ b/lib/process.js
@@ -1,0 +1,9 @@
+const reporter = require('./reporter.js')
+
+exports.exit = (code, msg) => {
+    if (msg && code > 0) {
+        reporter.print('')
+        reporter.error(msg)
+    }
+    process.exit(code)
+}

--- a/lib/prompt.js
+++ b/lib/prompt.js
@@ -1,15 +1,16 @@
 const inquirer = require('inquirer')
-const reporter = require('./reporter')
+const reporter = require('./reporter.js')
+const exit = require('./exit.js')
 
 const prompt = questions => {
     return inquirer.prompt(questions).catch(error => {
         if (error.isTtyError) {
             reporter.error('Failed to prompt for user input!')
-            process.exit(1)
+            exit(1)
         } else {
             reporter.error('An unknown error occured while prompting for input')
             reporter.debugErr(error)
-            process.exit(1)
+            exit(1)
         }
     })
 }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     },
     "dependencies": {
         "chalk": "^3.0.0",
+        "cross-spawn": "^7.0.3",
+        "find-up": "^5.0.0",
         "fs-extra": "^8.0.1",
         "inquirer": "^7.3.3",
         "request": "^2.88.0",


### PR DESCRIPTION
This is a port of the utils/run.js file from cli-style:
https://github.com/dhis2/cli-style/blob/2bfb5ef5ee2b26ff7e27594fe36cef9eb12b2360/src/utils/run.js

It introduces cross-spawn as the default way to spawn processes which
works well on other platforms (e.g. windows) and exposes additional
functions to spawn and use the result of processes.

Notably, it adds the bin() function that resolves a command to the
nearest node_modules/.bin folder based on the cwd.

This is needed for cli-style, but also now needed for cli-utils-cypress,
so makes sense to generalize it here.
