### PR TITLE
feat: add helper to identify the project root path

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ module.exports.namespace = require('./lib/namespace')
 module.exports.notifyOfUpdates = require('./lib/notifyOfUpdates')
 module.exports.tryCatchAsync = require('./lib/tryCatchAsync')
 module.exports.configDefaults = require('./lib/configDefaults')
+module.exports.findProjectRoot = require('./lib/findProjectRoot.js')
 
 // The Cache constructor
 module.exports.Cache = require('./lib/cache')

--- a/lib/findProjectRoot.js
+++ b/lib/findProjectRoot.js
@@ -1,0 +1,26 @@
+const process = require('process')
+const path = require('path')
+const findup = require('find-up')
+
+/*
+ * cwd		Specifies the current working directory to start the search from
+ * markers	Override the default markers that identify the root project directory
+ *
+ * returns the absolute path to the project root, or undefined if not found.
+ */
+module.exports = ({
+    cwd = process.cwd(),
+    markers = ['.git', '.github', 'yarn.lock', 'package-lock.json'],
+} = {}) =>
+    findup.sync(
+        directory => {
+            const amiroot = markers.map(i =>
+                findup.sync.exists(path.join(directory, i))
+            )
+            return amiroot.includes(true) && directory
+        },
+        {
+            cwd,
+            type: 'directory',
+        }
+    )


### PR DESCRIPTION
This is a port of the function in cli-style[1] that is able to find the
root project path in monorepos, which is now required in
cli-utils-cypress.

[1] https://github.com/dhis2/cli-style/blob/master/src/utils/paths.js#L10-L24