### PR TITLE
feat(reporter): log levels

### DIFF
--- a/lib/groupGlobalOptions.js
+++ b/lib/groupGlobalOptions.js
@@ -1,6 +1,1 @@
-const chalk = require('chalk')
-
-const globalOptions = ['help', 'version', 'config']
-module.exports = yargs => {
-    yargs.group(globalOptions, chalk.bold('Global Options'))
-}
+module.exports = (yargs, globalOptions = ['help', 'version', 'verbose', 'debug', 'quiet', 'config']) => yargs.group(globalOptions, 'Global Options:')

--- a/lib/groupGlobalOptions.js
+++ b/lib/groupGlobalOptions.js
@@ -1,1 +1,4 @@
-module.exports = (yargs, globalOptions = ['help', 'version', 'verbose', 'debug', 'quiet', 'config']) => yargs.group(globalOptions, 'Global Options:')
+module.exports = (
+    yargs,
+    globalOptions = ['help', 'version', 'verbose', 'debug', 'quiet', 'config']
+) => yargs.group(globalOptions, 'Global Options:')

--- a/lib/makeEntryPoint.js
+++ b/lib/makeEntryPoint.js
@@ -11,7 +11,25 @@ module.exports = ({ builder, handler }) => {
     builder(yargs)
 
     // Define global options
-    yargs.help().alias('h', 'help').version()
+    yargs
+        .help().alias('h', 'help')
+        .version().alias('v', 'version')
+        .option('verbose', {
+            type: 'boolean',
+            describe: 'Enable verbose messages',
+            global: true,
+        })
+        .option('debug', {
+            type: 'boolean',
+            describe: 'Enable debug messages',
+            global: true,
+        })
+        .option('quiet', {
+            type: 'boolean',
+            describe: 'Suppress non-error messages',
+            global: true,
+        })
+        .group(['help', 'version', 'verbose', 'debug', 'quiet'], 'Global options:')
 
     // Configuration loading
     yargs
@@ -25,8 +43,6 @@ module.exports = ({ builder, handler }) => {
         .pkgConf('d2') // Support d2 key in package.json
 
     yargs.updateStrings({
-        'Options:': chalk.bold(`Options:`),
-        'Commands:': chalk.bold('Commands:'),
         'Did you mean %s?': chalk.blue(`Did you mean ${chalk.bold('%s')}?`),
         'Not enough non-option arguments: got %s, need at least %s': chalk.red(
             'Missing required positional arguments (got %d of %d)'

--- a/lib/makeEntryPoint.js
+++ b/lib/makeEntryPoint.js
@@ -1,8 +1,9 @@
 const chalk = require('chalk')
 const fs = require('fs')
-const defaultConfig = require('./configDefaults')
-const cacheMiddleware = require('./cache/middleware')
-const reporter = require('./reporter')
+const defaultConfig = require('./configDefaults.js')
+const cacheMiddleware = require('./cache/middleware.js')
+const reporter = require('./reporter.js')
+const groupGlobalOptions = require('./groupGlobalOptions.js')
 
 module.exports = ({ builder, handler }) => {
     const yargs = require('yargs') // singleton
@@ -26,10 +27,9 @@ module.exports = ({ builder, handler }) => {
         })
         .option('quiet', {
             type: 'boolean',
-            describe: 'Suppress non-error messages',
+            describe: 'Enable quiet mode',
             global: true,
         })
-        .group(['help', 'version', 'verbose', 'debug', 'quiet'], 'Global options:')
 
     // Configuration loading
     yargs
@@ -41,6 +41,8 @@ module.exports = ({ builder, handler }) => {
         })
         .env('D2') // D2_* environment variables get mapped to argv
         .pkgConf('d2') // Support d2 key in package.json
+
+    groupGlobalOptions(yargs)
 
     yargs.updateStrings({
         'Did you mean %s?': chalk.blue(`Did you mean ${chalk.bold('%s')}?`),

--- a/lib/makeEntryPoint.js
+++ b/lib/makeEntryPoint.js
@@ -13,8 +13,10 @@ module.exports = ({ builder, handler }) => {
 
     // Define global options
     yargs
-        .help().alias('h', 'help')
-        .version().alias('v', 'version')
+        .help()
+        .alias('h', 'help')
+        .version()
+        .alias('v', 'version')
         .option('verbose', {
             type: 'boolean',
             describe: 'Enable verbose messages',

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -1,11 +1,35 @@
 const chalk = require('chalk')
 const util = require('util')
 
+/*
+ * Define the integer codes used for the log levels
+ *
+ * For a message to be printed, it must be lower or equal to the
+ * configured log level.
+ *
+ * The default log level is 1, and will print quiet and standard level
+ * messages.
+ *
+ * --quiet sets the log level to 0, and will not print standard
+ *  messages.
+ *
+ * --verbose sets the log level to 2, and will print all messages except
+ *  debug messages.
+ *
+ *  --debug is level 3 and will print all messages, which may be
+ *  extremely verbose as it is intended for debugging purposes.
+ */
+const QUIET_CODE = 0
+const STANDARD_CODE = 1
+const VERBOSE_CODE = 2
+const DEBUG_CODE = 3
+
 const config = {
-    verbose: false,
     quiet: false,
+    verbose: false,
     debug: false,
 }
+
 const middleware = ({
     verboseOption = 'verbose',
     quietOption = 'quiet',
@@ -22,82 +46,97 @@ const middleware = ({
     }
 }
 
+const loglevel = ({ quiet, verbose, debug }) => {
+    switch (true) {
+        case (quiet):
+            return QUIET_CODE
+        case (verbose):
+            return VERBOSE_CODE
+        case (debug):
+            return DEBUG_CODE
+        default:
+            return STANDARD_CODE
+    }
+}
+
 const levels = [
     {
+        name: 'pipe',
+        level: QUIET_CODE,
+        msgEnhancer: msg => msg,
+    },
+    {
+        name: 'pipeErr',
+        level: QUIET_CODE,
+        stderr: true,
+        msgEnhancer: msg => msg,
+    },
+
+    {
+        name: 'print',
+        level: STANDARD_CODE,
+        msgEnhancer: msg => `${msg}\n`,
+    },
+    {
+        name: 'printErr',
+        level: STANDARD_CODE,
+        stderr: true,
+        msgEnhancer: msg => `${msg}\n`,
+    },
+    {
+        name: 'info',
+        level: STANDARD_CODE,
+        stderr: true,
+        msgEnhancer: msg => `${chalk.cyan(msg)}\n`,
+    },
+    {
+        name: 'warn',
+        level: STANDARD_CODE,
+        stderr: true,
+        msgEnhancer: msg =>
+            `${chalk.bold.yellow('[WARNING]')} ${chalk.yellow(msg)}\n`,
+    },
+    {
+        name: 'error',
+        level: STANDARD_CODE,
+        stderr: true,
+        msgEnhancer: msg => `${chalk.bold.red('[ERROR]')} ${chalk.red(msg)}\n`,
+    },
+
+    {
+        name: 'log',
+        level: VERBOSE_CODE,
+        msgEnhancer: msg => `${msg}\n`,
+    },
+    {
+        name: 'dump',
+        level: VERBOSE_CODE,
+        msgEnhancer: msg => chalk.gray(`${msg}`),
+    },
+    {
+        name: 'dumpErr',
+        level: VERBOSE_CODE,
+        stderr: true,
+        msgEnhancer: msg => chalk.bgRed(`${msg}`),
+    },
+
+    {
         name: 'debug',
-        verbose: true,
+        level: DEBUG_CODE,
         stderr: true,
         msgEnhancer: msg =>
             `${chalk.bold.gray('[DEBUG]')} ${chalk.gray(msg)}\n`,
     },
     {
         name: 'debugErr',
-        verbose: true,
+        level: DEBUG_CODE,
         stderr: true,
         msgEnhancer: msg =>
             `${chalk.bold.red.dim('[DEBUG ERROR]')} ${chalk.red.dim(msg)}\n`,
     },
-    {
-        name: 'info',
-        verbose: false,
-        stderr: true,
-        msgEnhancer: msg => `${chalk.cyan(msg)}\n`,
-    },
-    {
-        name: 'dump',
-        verbose: true,
-        quiet: true,
-        msgEnhancer: msg => chalk.gray(`${msg}`),
-    },
-    {
-        name: 'pipe',
-        verbose: false,
-        quiet: true,
-        msgEnhancer: msg => msg,
-    },
-    {
-        name: 'pipeErr',
-        verbose: false,
-        quiet: true,
-        stderr: true,
-        msgEnhancer: msg => msg,
-    },
-    {
-        name: 'dumpErr',
-        verbose: true,
-        stderr: true,
-        msgEnhancer: msg => chalk.bgRed(`${msg}`),
-    },
-    {
-        name: 'print',
-        verbose: false,
-        quiet: true,
-        msgEnhancer: msg => `${msg}\n`,
-    },
-    {
-        name: 'warn',
-        verbose: false,
-        stderr: true,
-        msgEnhancer: msg =>
-            `${chalk.bold.yellow('[WARNING]')} ${chalk.yellow(msg)}\n`,
-    },
-    {
-        name: 'printErr',
-        verbose: false,
-        stderr: true,
-        msgEnhancer: msg => `${msg}\n`,
-    },
-    {
-        name: 'error',
-        verbose: false,
-        stderr: true,
-        msgEnhancer: msg => `${chalk.bold.red('[ERROR]')} ${chalk.red(msg)}\n`,
-    },
 ]
 
-const shouldLog = lvl =>
-    (!lvl.verbose || config.verbose !== false) && // If config.verbose is still undefined we shouldn't suppress logs
-    (!config.quiet || lvl.quiet === true)
+const shouldLog = lvl => lvl.level <= loglevel(config)
 
 const write = (lvl = {}, msg, args) => {
     if (shouldLog(lvl)) {
@@ -115,6 +154,7 @@ const write = (lvl = {}, msg, args) => {
         }
     }
 }
+
 const reporter = {}
 
 levels.forEach(lvl => {

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -4,16 +4,21 @@ const util = require('util')
 const config = {
     verbose: false,
     quiet: false,
+    debug: false,
 }
 const middleware = ({
     verboseOption = 'verbose',
     quietOption = 'quiet',
+    debugOption = 'debug',
 } = {}) => argv => {
     if (argv[verboseOption]) {
         config.verbose = true
     }
     if (argv[quietOption]) {
         config.quiet = true
+    }
+    if (argv[debugOption]) {
+        config.debug = true
     }
 }
 

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -48,11 +48,11 @@ const middleware = ({
 
 const loglevel = ({ quiet, verbose, debug }) => {
     switch (true) {
-        case (quiet):
+        case quiet:
             return QUIET_CODE
-        case (verbose):
+        case verbose:
             return VERBOSE_CODE
-        case (debug):
+        case debug:
             return DEBUG_CODE
         default:
             return STANDARD_CODE


### PR DESCRIPTION
- refactor: add global options to yargs
- feat(reporter): add reporter.log function

Adds a group in the `--help` text for global options that are added by the `cli-helpers-engine`:

![2021-06-08-105804_1060x589_scrot](https://user-images.githubusercontent.com/185449/121155811-6d301400-c848-11eb-9340-8f36efb0453c.png)

Adds integer based logging groups so it's easier to decide if we `shouldLog` a message.

Adds a `reporter.log` function that prints to `stdout` in verbose mode, that is useful to provide more info when needed, in combination with `reporter.print` that prints to `stdout` in standard mode.