### PR TITLE
fix: catch unhandled rejections

### DIFF
--- a/lib/makeEntryPoint.js
+++ b/lib/makeEntryPoint.js
@@ -5,6 +5,10 @@ const defaultConfig = require('./configDefaults.js')
 const groupGlobalOptions = require('./groupGlobalOptions.js')
 const reporter = require('./reporter.js')
 
+process.on('unhandledRejection', (err) => {
+    throw err
+})
+
 module.exports = ({ builder, handler }) => {
     const yargs = require('yargs') // singleton
     // TODO: Show description


### PR DESCRIPTION
This implements a listener for unhandledRejection errors that bubble up
all the way to the node process. Node 16 crashes on these exceptions,
which is a breaking change from Node 14.

This style supports Node 12+.