### PR TITLE
feat(pretty-print): add a helper to print relative paths

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@ module.exports.exec = require('./lib/exec.js')
 module.exports.reporter = require('./lib/reporter')
 module.exports.exit = require('./lib/exit.js')
 module.exports.prompt = require('./lib/prompt')
+module.exports.prettyPrint = require('./lib/prettyPrint.js')
 
 // Access to wrapped libraries
 module.exports.chalk = require('chalk')

--- a/lib/prettyPrint.js
+++ b/lib/prettyPrint.js
@@ -1,0 +1,3 @@
+const path = require('path')
+exports.relativePath = (fp, cwd = process.cwd()) =>
+    path.isAbsolute(fp) ? path.relative(cwd, fp) : fp


### PR DESCRIPTION
feat(pretty-print): add a helper to print relative paths
