### PR TITLE
fix(create-module-loader): handle case where findProject root returns undefined

### DIFF
--- a/lib/createModuleLoader.js
+++ b/lib/createModuleLoader.js
@@ -14,7 +14,9 @@ module.exports = ({ parentModule, preferLocal = true }) => {
 
     // create a require fn bound to the cwd project's node_modules
     const root = findProjectRoot({ markers: ['package.json'] })
-    const rootRequire = createRequire(path.resolve(root, 'package.json'))
+    const rootRequire = createRequire(
+        root ? path.resolve(root, 'package.json') : '/'
+    )
 
     if (!preferLocal) {
         reporter.warn('Project-local module resolution for tools is disabled.')


### PR DESCRIPTION
In some cases, such as when `cli-helpers-engine` is being used by a global install of `d2`, `findProjectRoot` will return `undefined`. This results in `path.resolve` throwing the error `The “path” argument must be of type string. Received undefined` and so breaks `d2` commands.

This PR fixes this issue by using the root path `/` as a fallback.

Once this is merged, we need to bump `cli-helpers-engine` in `@dhis2/cli`.