### PR TITLE
fix(exec): allow xspawn's stdio config option without breaking

### DIFF
--- a/lib/exec.js
+++ b/lib/exec.js
@@ -22,27 +22,41 @@ function exec({ cmd, args, env, pipe, captureOut, captureErr, ...opts }) {
         })
         let output = captureOut || captureErr ? '' : undefined
 
-        child.stdout.on('data', (data) => {
-            if (captureOut) {
-                output += data
-            }
-            if (!pipe) {
-                reporter.dump(data)
-            } else {
-                reporter.pipe(data)
-            }
-        })
+        // if the `stdio` option is used on xspawn, `child.stdout` and/or
+        // `child.stderr` could be null
+        if (child.stdout) {
+            child.stdout.on('data', (data) => {
+                if (captureOut) {
+                    output += data
+                }
+                if (!pipe) {
+                    reporter.dump(data)
+                } else {
+                    reporter.pipe(data)
+                }
+            })
+        } else if (pipe || captureOut) {
+            reporter.warn(
+                'A custom stdio option has been used on this exec command for stdout. Pipe and captureOut options will not work.'
+            )
+        }
 
-        child.stderr.on('data', (data) => {
-            if (captureErr) {
-                output += data
-            }
-            if (!pipe) {
-                reporter.pipeErr(data)
-            } else {
-                reporter.printErr(data)
-            }
-        })
+        if (child.stderr) {
+            child.stderr.on('data', (data) => {
+                if (captureErr) {
+                    output += data
+                }
+                if (!pipe) {
+                    reporter.pipeErr(data)
+                } else {
+                    reporter.printErr(data)
+                }
+            })
+        } else if (pipe || captureErr) {
+            reporter.warn(
+                'A custom stdio option has been used on this exec command for stderr. Pipe and captureErr options will not work.'
+            )
+        }
 
         child.on('close', (code) => {
             if (code !== 0) {


### PR DESCRIPTION
Using the [`stdio: 'inherit'`](https://nodejs.org/api/child_process.html#optionsstdio) option on the `spawn`/`xspawn` command when starting a dev server with Vite enables the nice colorful, helpful, and interactive output from Vite in the console -- see the screenshot below 🙂 

As-is though, once the `stdio` is set, the existing `child.stdout.on()` listeners throw an error: `TypeError: Cannot read properties of null (reading 'on') `. The small change in this PR allows usage of the `stdio` option on the `exec` command. I tested it out in the app platform by editing the local file in node_modules:

![Screenshot 2024-05-07 at 2 39 01 PM](https://github.com/dhis2/cli-helpers-engine/assets/49666798/3ff58b99-bc06-4740-b370-8e7f44667066)
